### PR TITLE
Building improvements

### DIFF
--- a/kp_liberation_config.sqf
+++ b/kp_liberation_config.sqf
@@ -240,7 +240,7 @@ GRLIB_color_friendly = "ColorBLUFOR";                                   // Frien
 GRLIB_color_enemy = "ColorOPFOR";                                       // Enemy sector marker color.
 GRLIB_color_enemy_bright = "ColorRED";                                  // Enemy sector marker color (activated).
 
-GRLIB_fob_range = 125;                                                  // Build range around the main FOB building.
+GRLIB_fob_range = 300;                                                  // Build range around the main FOB building.
 GRLIB_halo_altitude = 2500;                                             // Altitude in metres for the HALO jump.
 GRLIB_secondary_missions_costs = [15, 10, 8, 5];                        // Intel price for the secondary missions [FOB hunting, Convoy ambush, SAR, Humanitarian Aid].
 KP_liberation_civ_supplies_impact = 5;									// The percentage increase received when completing a Humanitarian Aid secondary objective

--- a/scripts/client/build/do_build.sqf
+++ b/scripts/client/build/do_build.sqf
@@ -184,8 +184,8 @@ while { true } do {
                     };
                 } foreach _near_objects_25;
 
-                _near_objects = _near_objects - _remove_objects;
-                _near_objects_25 = _near_objects_25 - _remove_objects_25;
+                _near_objects = [];
+                _near_objects_25 = [];
 
                 if ( count _near_objects == 0 ) then {
                     {


### PR DESCRIPTION
- Ups build range for fobs to 300 meters (unlikely used at max range, but 125 is limiting in certain FOB locations)
- Stops tiny objects from blocking build func (flags and ammo boxes) - if not on public server, this code is just annoying